### PR TITLE
using

### DIFF
--- a/overlay/popupoverlay.js
+++ b/overlay/popupoverlay.js
@@ -48,8 +48,8 @@ ol.Overlay.Popup = function (options)
 	options.stopEvent = true;
 	d.on("mousedown touchstart", function(e){ e.stopPropagation(); })
 
-	ol.Overlay.call(this, options);
 	this._elt = elt;
+	ol.Overlay.call(this, options);
 			
 	// call setPositioning first in constructor so getClassPositioning is called only once
 	this.setPositioning(options.positioning);


### PR DESCRIPTION
using Overlay with default positioning like 
`
this.__popup = new ol.Overlay.Popup({
        positioning : "center-center",
        CloseBox : false,
        onclose : function() {
          this._setNativeDropMode(false);
        }.bind(this),
        onshow : function() {
          this._setNativeDropMode(true);
        }
`

needs defined _elt in setPositioning_