### PR TITLE
fix style reference bug

### DIFF
--- a/src/interaction/DrawRegular.js
+++ b/src/interaction/DrawRegular.js
@@ -60,7 +60,7 @@ var ol_interaction_DrawRegular = function(options)
 		new ol_style_Style({
 			stroke: new ol_style_Stroke({ color: white, width: width + 2 })
 		}),
-		new ol.style.Style({
+		new ol_style_Style({
 			image: new ol_style_Circle({
 				radius: width * 2,
 				fill: new ol_style_Fill({ color: blue }),


### PR DESCRIPTION
Style is still referenced as ol.style.Style in some places and ol_style_Style in others. There are many more places in the code where  `import ol_style_Style from 'ol/style/style'` and `ol_style_Style` should be used over `ol.style.Style`.