### PR TITLE
more appropriate cursors for ol.interaction.Transform

### DIFF
--- a/src/interaction/Transform.js
+++ b/src/interaction/Transform.js
@@ -18,8 +18,8 @@ import ol_extent from 'ol/extent'
  * @extends {ol_interaction_Pointer}
  * @fires select | rotatestart | rotating | rotateend | translatestart | translating | translateend | scalestart | scaling | scaleend
  * @param {any} options
- *  @param {Array<ol.Layer>} options.layers array of layers to transform, 
- *  @param {ol.Collection<ol.Feature>} options.features collection of feature to transform, 
+ *  @param {Array<ol.Layer>} options.layers array of layers to transform,
+ *  @param {ol.Collection<ol.Feature>} options.features collection of feature to transform,
  *	@param {ol.EventsConditionType|undefined} options.addCondition A function that takes an ol.MapBrowserEvent and returns a boolean to indicate whether that event should be handled. default: ol.events.condition.never.
  *	@param {number | undefined} options.hitTolerance Tolerance to select feature in pixel, default 0
  *	@param {bool} options.translateFeature Translate when click on feature
@@ -31,13 +31,13 @@ import ol_extent from 'ol/extent'
  *	@param {} options.style list of ol.style for handles
  *
  */
-var ol_interaction_Transform = function(options) {	
+var ol_interaction_Transform = function(options) {
   if (!options) options = {};
 	var self = this;
 
 	// Create a new overlay layer for the sketch
 	this.handles_ = new ol_Collection();
-	this.overlayLayer_ = new ol_layer_Vector({	
+	this.overlayLayer_ = new ol_layer_Vector({
     source: new ol_source_Vector({
       features: this.handles_,
       useSpatialIndex: false
@@ -51,7 +51,7 @@ var ol_interaction_Transform = function(options) {
   });
 
 	// Extend pointer
-	ol_interaction_Pointer.call(this, {	
+	ol_interaction_Pointer.call(this, {
     handleDownEvent: this.handleDownEvent_,
 		handleDragEvent: this.handleDragEvent_,
 		handleMoveEvent: this.handleMoveEvent_,
@@ -94,18 +94,19 @@ ol.inherits(ol_interaction_Transform, ol_interaction_Pointer);
 /** Cursors for transform
 */
 ol_interaction_Transform.prototype.Cursors = {
-  'default':	'auto',
-	'select':	'pointer',
-	'translate':'move',
-	'rotate':	'move',
-	'scale':	'ne-resize', 
-	'scale1':	'nw-resize', 
-	'scale2':	'ne-resize', 
-	'scale3':	'nw-resize',
-	'scalev':	'e-resize', 
-	'scaleh1':	'n-resize', 
-	'scalev2':	'e-resize', 
-	'scaleh3':	'n-resize'
+  'default': 'auto',
+  'select': 'pointer',
+  'translate': 'move',
+  'rotate': 'url(\'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABcAAAAXAgMAAACdRDwzAAAAAXNSR0IArs4c6QAAAAlQTFRF////////AAAAjvTD7AAAAAF0Uk5TAEDm2GYAAAABYktHRACIBR1IAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH2wwSEgUFmXJDjQAAAEZJREFUCNdjYMAOuCCk6goQpbp0GpRSAFKcqdNmQKgIILUoNAxIMUWFhoKosNDQBKDgVAilCqcaQBogFFNoGNjsqSgUTgAAM3ES8k912EAAAAAASUVORK5CYII=\') 5 5, auto',
+  'rotate0': 'url(\'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAKTWlDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQWaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28AAgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaOWJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHiwmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryMAgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0lYqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHiNLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYAQH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6cwR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBiewhi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1cQPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqOY4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hMWEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgohJZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSUEko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/pdLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Yb1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7OUndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsbdi97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxrPGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H08PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+Hvqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsGLww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjgR2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWYEpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1IreZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/PbFWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYji1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVkVe9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0IbwDa0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vzDoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+yCW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawto22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtdUV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3rO9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv9563Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+UPPR+mPHp9BP9z7nfP78L/eE8/sl0p8zAAAABGdBTUEAALGOfPtRkwAAACBjSFJNAAB6JQAAgIMAAPn/AACA6QAAdTAAAOpgAAA6mAAAF2+SX8VGAAAAZUlEQVR42sSTQQrAMAgEHcn/v7w9tYgNNsGW7kkI2TgbRZJ15NbU+waAAFV11MiXz0yq2sxMEiVCDDcHLeky8nQAUDJnM88IuyGOGf/n3wjcQ1zhf+xgxSS+PkXY7aQ9yvy+jccAMs9AI/bwo38AAAAASUVORK5CYII=\') 5 5, auto',
+  'scale': 'nesw-resize',
+  'scale1': 'nwse-resize',
+  'scale2': 'nesw-resize',
+  'scale3': 'nwse-resize',
+  'scalev': 'ew-resize',
+  'scaleh1': 'ns-resize',
+  'scalev2': 'ew-resize',
+  'scaleh3': 'ns-resize'
 };
 
 /**
@@ -126,7 +127,7 @@ ol_interaction_Transform.prototype.setMap = function(map) {
 
 /**
  * Activate/deactivate interaction
- * @param {bool} 
+ * @param {bool}
  * @api stable
  */
 ol_interaction_Transform.prototype.setActive = function(b) {
@@ -210,8 +211,8 @@ ol_interaction_Transform.prototype.setStyle = function(style, olstyle) {
 };
 
 /** Get Feature at pixel
- * @param {ol.Pixel} 
- * @return {ol.feature} 
+ * @param {ol.Pixel}
+ * @return {ol.feature}
  * @private
  */
 ol_interaction_Transform.prototype.getFeatureAtPixel_ = function(pixel) {
@@ -325,7 +326,7 @@ ol_interaction_Transform.prototype.select = function(feature, add) {
 ol_interaction_Transform.prototype.handleDownEvent_ = function(evt) {
 	var sel = this.getFeatureAtPixel_(evt.pixel);
 	var feature = sel.feature;
-	if (this.selection_.length 
+	if (this.selection_.length
 		&& this.selection_.indexOf(feature) >=0
 		&& ((this.ispt_ && this.get('translate')) || this.get('translateFeature'))
 	){
@@ -347,17 +348,22 @@ ol_interaction_Transform.prototype.handleDownEvent_ = function(evt) {
 		this.extent_ = (ol_geom_Polygon.fromExtent(extent)).getCoordinates()[0];
 		if (this.mode_==='rotate') {
 			this.center_ = this.getCenter() || ol_extent.getCenter(extent);
+
+			// we are now rotating (cursor down on rotate mode), so apply the grabbing cursor
+			var element = evt.map.getTargetElement();
+			element.style.cursor = this.Cursors.rotate0;
+			this.previousCursor_ = element.style.cursor;
 		} else {
 			this.center_ = ol_extent.getCenter(extent);
 		}
 		this.angle_ = Math.atan2(this.center_[1]-evt.coordinate[1], this.center_[0]-evt.coordinate[0]);
 
-		this.dispatchEvent({ 
-			type: this.mode_+'start', 
+		this.dispatchEvent({
+			type: this.mode_+'start',
 			feature: this.selection_[0], // backward compatibility
-			features: this.selection_, 
-			pixel: evt.pixel, 
-			coordinate: evt.coordinate 
+			features: this.selection_,
+			pixel: evt.pixel,
+			coordinate: evt.coordinate
 		});
 		return true;
 	}
@@ -411,13 +417,13 @@ ol_interaction_Transform.prototype.handleDragEvent_ = function(evt) {
 				}
 			}
 			this.drawSketch_(true);
-			this.dispatchEvent({ 
-				type:'rotating', 
-				feature: this.selection_[0], 
-				features: this.selection_, 
-				angle: a-this.angle_, 
-				pixel: evt.pixel, 
-				coordinate: evt.coordinate 
+			this.dispatchEvent({
+				type:'rotating',
+				feature: this.selection_[0],
+				features: this.selection_,
+				angle: a-this.angle_,
+				pixel: evt.pixel,
+				coordinate: evt.coordinate
 			});
 			break;
 		}
@@ -434,13 +440,13 @@ ol_interaction_Transform.prototype.handleDragEvent_ = function(evt) {
 			});
 
 			this.coordinate_ = evt.coordinate;
-			this.dispatchEvent({ 
-				type:'translating', 
-				feature: this.selection_[0], 
-				features: this.selection_, 
-				delta:[deltaX,deltaY], 
-				pixel: evt.pixel, 
-				coordinate: evt.coordinate 
+			this.dispatchEvent({
+				type:'translating',
+				feature: this.selection_[0],
+				features: this.selection_,
+				delta:[deltaX,deltaY],
+				pixel: evt.pixel,
+				coordinate: evt.coordinate
 			});
 			break;
 		}
@@ -466,7 +472,7 @@ ol_interaction_Transform.prototype.handleDragEvent_ = function(evt) {
         var geometry = this.geoms_[i].clone();
         geometry.applyTransform(function(g1, g2, dim) {
           if (dim<2) return g2;
-          
+
           for (var i=0; i<g1.length; i+=dim) {
             if (scx!=1) g2[i] = center[0] + (g1[i]-center[0])*scx;
             if (scy!=1) g2[i+1] = center[1] + (g1[i+1]-center[1])*scy;
@@ -476,13 +482,13 @@ ol_interaction_Transform.prototype.handleDragEvent_ = function(evt) {
         f.setGeometry(geometry);
       }
 			this.drawSketch_();
-			this.dispatchEvent({ 
-				type:'scaling', 
-				feature: this.selection_[0], 
-				features: this.selection_, 
-				scale:[scx,scy], 
-				pixel: evt.pixel, 
-				coordinate: evt.coordinate 
+			this.dispatchEvent({
+				type:'scaling',
+				feature: this.selection_[0],
+				features: this.selection_,
+				scale:[scx,scy],
+				pixel: evt.pixel,
+				coordinate: evt.coordinate
 			});
 		}
 		default: break;
@@ -494,19 +500,19 @@ ol_interaction_Transform.prototype.handleDragEvent_ = function(evt) {
  */
 ol_interaction_Transform.prototype.handleMoveEvent_ = function(evt) {
 	// console.log("handleMoveEvent");
-	if (!this.mode_) 
+	if (!this.mode_)
 	{	var map = evt.map;
 		var sel = this.getFeatureAtPixel_(evt.pixel);
 		var element = evt.map.getTargetElement();
-		if (sel.feature) 
+		if (sel.feature)
 		{	var c = sel.handle ? this.Cursors[(sel.handle||'default')+(sel.constraint||'')+(sel.option||'')] : this.Cursors.select;
-			
-			if (this.previousCursor_===undefined) 
+
+			if (this.previousCursor_===undefined)
 			{	this.previousCursor_ = element.style.cursor;
 			}
 			element.style.cursor = c;
-		} 
-		else  
+		}
+		else
 		{	if (this.previousCursor_!==undefined) element.style.cursor = this.previousCursor_;
 			this.previousCursor_ = undefined;
 		}
@@ -518,15 +524,22 @@ ol_interaction_Transform.prototype.handleMoveEvent_ = function(evt) {
  * @return {boolean} `false` to stop the drag sequence.
  */
 ol_interaction_Transform.prototype.handleUpEvent_ = function(evt) {
-  //dispatchEvent 
-	this.dispatchEvent({ 
-		type:this.mode_+'end', 
-		feature: this.selection_[0], 
-		features: this.selection_, 
-		oldgeom: this.geoms_[0], 
-		oldgeoms: this.geoms_ 
+  // remove rotate0 cursor on Up event, otherwise it's stuck on grab/grabbing
+  if (this.mode_ === 'rotate') {
+    var element = evt.map.getTargetElement();
+    element.style.cursor = this.Cursors.default;
+    this.previousCursor_ = undefined;
+  }
+
+  //dispatchEvent
+	this.dispatchEvent({
+		type:this.mode_+'end',
+		feature: this.selection_[0],
+		features: this.selection_,
+		oldgeom: this.geoms_[0],
+		oldgeoms: this.geoms_
 	});
-	
+
 	this.drawSketch_();
 	this.mode_ = null;
 	return false;


### PR DESCRIPTION
- Changed the four cursors for **scaling** from a single arrow to the bi-directional diagonal version.
e.g. from `ne-resize` to `nesw-resize`
![image](https://user-images.githubusercontent.com/3810017/40833336-8f4f515a-6585-11e8-9b05-9e33de09f4eb.png) ![image](https://user-images.githubusercontent.com/3810017/40833346-9a90901a-6585-11e8-9ca1-d3e7ebd703eb.png)

- Changed the cursor for **rotate** to be `grab`/`grabbing`, including logic to set/reset the cursor when rotate finishes.
**Note:** grab is [unsupported in many browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Browser_compatibility) without a prefix, so I decided to inline two small base64 images for the `grab`/`grabbing` cursor.