### PR TITLE
#174 fix translate when selection is managed externally

### DIFF
--- a/src/interaction/Transform.js
+++ b/src/interaction/Transform.js
@@ -238,7 +238,13 @@ ol_interaction_Transform.prototype.getFeatureAtPixel_ = function(pixel) {
         if (found) return { feature: feature, handle:feature.get('handle'), constraint:feature.get('constraint'), option:feature.get('option') };
       }
       // No seletion
-      if (!self.get('selection')) return null;
+      if (!self.get('selection')) {
+        // Return the currently selected feature the user is interacting with.
+        if (self.selection_.some(function(f) { return feature === f; })) {
+          return { feature: feature };
+        }
+        return null;
+      }
       // filter condition
       if (self._filter) {
         if (self._filter(feature,layer)) return { feature: feature };


### PR DESCRIPTION
When selection is managed `selection: false` we need to return the currently selected feature in order to support translate functionality. This simply identifies which of the currently selected features the user is interacting with.