### PR TITLE
Simplify snapguide clear guides

### DIFF
--- a/src/interaction/SnapGuides.js
+++ b/src/interaction/SnapGuides.js
@@ -134,15 +134,9 @@ ol_interaction_SnapGuides.prototype.setActive = function(active)
 }
 
 /** Clear previous added guidelines
-* @param {Array<ol.Feature> | undefined} features a list of feature to remove, default remove all feature
 */
-ol_interaction_SnapGuides.prototype.clearGuides = function(features)
-{	if (!features) this.overlaySource_.clear();
-	else
-	{	for (var i=0, f; f=features[i]; i++)
-		{	this.overlaySource_.removeFeature(f);
-		}
-	}
+ol_interaction_SnapGuides.prototype.clearGuides = function()
+{ this.overlaySource_.clear();
 }
 
 /** Get guidelines
@@ -233,7 +227,7 @@ ol_interaction_SnapGuides.prototype.setDrawInteraction = function(drawi) {
 		}
 
 		if (l != nb && (self.enableInitialGuides_ ? l >= s : l > s)) {
-			self.clearGuides(features);
+			self.clearGuides();
 			if (l > s) {
 				features = self.addOrthoGuide([coord[l - s], coord[l - s - 1]]);
 			}
@@ -249,7 +243,7 @@ ol_interaction_SnapGuides.prototype.setDrawInteraction = function(drawi) {
 	});
 	// end drawing, clear directions
 	drawi.on ("drawend", function(e) {
-		self.clearGuides(features);
+		self.clearGuides();
 		e.feature.getGeometry().un("change", setGuides);
 		nb = 0;
 		features = [];
@@ -288,7 +282,7 @@ ol_interaction_SnapGuides.prototype.setModifyInteraction = function (modifyi) {
 
 		var l = coord.length;
 
-		self.clearGuides(features);
+		self.clearGuides();
 		features = self.addOrthoGuide([coord[mod(idx - 1, l)], coord[mod(idx - 2, l)]]);
 		features = features.concat(self.addGuide([coord[mod(idx - 1, l)], coord[mod(idx - 2, l)]]));
 		features = features.concat(self.addGuide([coord[mod(idx + 1, l)], coord[mod(idx + 2, l)]]));
@@ -303,7 +297,7 @@ ol_interaction_SnapGuides.prototype.setModifyInteraction = function (modifyi) {
 
 
 	function drawEnd(e) {
-		self.clearGuides(features);
+		self.clearGuides();
 		features = [];
 	}
 


### PR DESCRIPTION
There is currently a bug with snap guides where it sometimes is tracking features that have already been removed from olVectorSource. This can occur when drawing a line string with 2 points with `enableInitialGuides`. 

I didn't look into it too deeply but when a line string is finished drawing a `"change"` event is fired on the feature's geometry adding an additional point which is identical to `n - 1` points. When the draw interaction completes the feature will have 2 points instead of 3. In this scenario, for whatever reason the vector source is tracking 6 features while the `features` array snap guides is tracking has 9 features.

Rather than investigating further it seemed to make more sense to just remove all guides whenever we call `clearGuides()` as internally at least `features` always corresponds to all the features in `overlaySource_`