### PR TITLE
Wrap options.className in the condition to fix the issue #204

### DIFF
--- a/src/control/Bar.js
+++ b/src/control/Bar.js
@@ -23,10 +23,12 @@ var ol_control_Bar = function(options) {
   if (!options) options={};
 	var element = document.createElement("div");
       element.classList.add('ol-unselectable', 'ol-control', 'ol-bar');
-  var classes = options.className.split(' ').filter(function(className) {
-    return className.length > 0;
-  });
-	if (options.className) element.classList.add.apply(element.classList, classes);
+	if (options.className) {
+		var classes = options.className.split(' ').filter(function(className) {
+			return className.length > 0;
+		});
+		element.classList.add.apply(element.classList, classes)
+	};
 	if (options.group) element.classList.add('ol-group');
 
 	ol_control_Control.call(this, {


### PR DESCRIPTION
This PR solves #204 
It's a side effect of one of my previous commits. I tried to split many classes if any but I didn't check if any `className` has been set.