### PR TITLE
Fixed ol_ext_inherits import issue in HexBin.js

### DIFF
--- a/src/source/HexBin.js
+++ b/src/source/HexBin.js
@@ -2,7 +2,7 @@
   released under the CeCILL-B license (French BSD license)
   (http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.txt).
 */
-import ol_ext_inherits from 'ol'
+import ol_ext_inherits from '../util/ext'
 import ol_geom_Polygon from 'ol/geom/Polygon'
 
 import ol_source_BinBase from './BinBase'


### PR DESCRIPTION
HexBin.js was importing ol_ext_inherits from ol instead of '../util/ext' which was preventing it from being imported for use in our React project. Modified it to use the same import statement as other components.