### PR TITLE
Add element option to use instead of content option

### DIFF
--- a/src/control/Button.js
+++ b/src/control/Button.js
@@ -86,4 +86,20 @@ ol_control_Button.prototype.setHtml = function(html) {
 	ol_ext_element.setHTML (this.button_, html);
 };
 
+/**
+ * Add event listener
+ * @returns {HTMLButtonElement}
+ */
+ol_control_Button.prototype.on = function(event, listener) {
+	this.button_.addEventListener(event, listener);
+};
+
+/**
+ * Remove event listener
+ * @returns {HTMLButtonElement}
+ */
+ol_control_Button.prototype.un = function(event, listener) {
+	this.button_.removeEventListener(event, listener);
+};
+
 export default ol_control_Button

--- a/src/control/Overlay.js
+++ b/src/control/Overlay.js
@@ -28,10 +28,23 @@ var ol_control_Overlay = function(options) {
   element.classList.add('ol-unselectable', 'ol-overlay');
   //if (options.className) element.classList.add(options.className);
 */
-  var element = ol_ext_element.create('DIV', {
-    className: 'ol-unselectable ol-overlay '+(options.className||''),
-    html: options.content
-  });
+  var element;
+  if (options.element) {
+    element = options.element;
+    element.setAttribute('class', (options.className || '') + ' ol-unselectable ol-overlay');
+    
+    if (options.closeBox){
+      var cb = document.createElement("div");
+      cb.classList.add("ol-closebox");
+      cb.addEventListener("click", function(){self.hide();});
+      elt.insertBefore(cb, elt.firstChild);
+    }
+  } else {
+    element = ol_ext_element.create('DIV', {
+      className: 'ol-unselectable ol-overlay ' + (options.className || ''),
+      html: options.content
+    });
+  }
   ol_control_Control.call(this, {
     element: element,
     target: options.target
@@ -43,7 +56,9 @@ var ol_control_Overlay = function(options) {
   this.set("closeBox", options.closeBox);
 
   this._timeout = false;
-  this.setContent (options.content);
+  if (options.content){
+    this.setContent (options.content);
+  }
 };
 ol_ext_inherits(ol_control_Overlay, ol_control_Control);
 


### PR DESCRIPTION
Add an option name `element` to use instead of `content` option, using this option you can make the overlay control show an HTML element which content may change from anywhere and you don't have to call the `setContent` function to update the overlay.

```
var overlay = new ol_control_Overlay({
  element: document.getElementById('my-element'),
  ....
})
```