### PR TITLE
Orphaned featureListener fix and support for Transform in rotated view

### DIFF
--- a/src/interaction/Transform.js
+++ b/src/interaction/Transform.js
@@ -140,6 +140,9 @@ ol_interaction_Transform.prototype.setMap = function(map) {
   }
   ol_interaction_Pointer.prototype.setMap.call (this, map);
   this.overlayLayer_.setMap(map);
+  if (map === null) {
+    this.select(null);
+  }
   if (map !== null) {
     this.isTouch = /touch/.test(map.getViewport().className);
     this.setDefaultStyle();


### PR DESCRIPTION
Commit 6d0143 fixes the case where features(s) to transform are selected, then the Transform interaction is removed from the map. The underlying featureListeners remain subscribed; if the Transform interaction is later added back to the map, then upon feature modification the stale listeners are called and crash with undefined references.