### PR TITLE
Fixed bug preventing deselect properly a feature

### DIFF
--- a/src/interaction/Transform.js
+++ b/src/interaction/Transform.js
@@ -358,8 +358,8 @@ ol_interaction_Transform.prototype.select = function(feature, add) {
   if (add) {
     this.selection_.push(feature);
   } else {
-    this.selection_.clear()
-    this.selection_.push(feature);
+	var index = this.selection_.getArray().indexOf(feature);
+	this.selection_.removeAt(index);	
   }
   this.ispt_ = (this.selection_.getLength()===1 ? (this.selection_.item(0).getGeometry().getType() == "Point") : false);
   this.iscircle_ = (this.selection_.getLength()===1 ? (this.selection_.item(0).getGeometry().getType() == "Circle") : false);


### PR DESCRIPTION
Corrected misleading behaivor on deselecting features: now the function .select( feature, false) is working properly. Previously the function was clearing all the features from the array selection, and then pushing the "deselected feature". It was working as an inverse selection, or so.