### PR TITLE
Avoid redundant drawSketch calls when feature is modified by Transform

### DIFF
--- a/src/interaction/Transform.js
+++ b/src/interaction/Transform.js
@@ -415,7 +415,9 @@ ol_interaction_Transform.prototype.watchFeatures_ = function() {
   this.selection_.forEach(function(f) {
     this._featureListeners.push(
       f.on('change', function() {
-        this.drawSketch_();
+        if (!this.isUpdating_) {
+          this.drawSketch_();
+        }
       }.bind(this))
     );
   }.bind(this));
@@ -544,6 +546,7 @@ ol_interaction_Transform.prototype.setCenter = function(c) {
 ol_interaction_Transform.prototype.handleDragEvent_ = function(evt) {
   if (!this._handleEvent(evt, this.features_)) return;
   var i, f, geometry;
+  this.isUpdating_ = true;
   switch (this.mode_) {
     case 'rotate': {
       var a = Math.atan2(this.center_[1]-evt.coordinate[1], this.center_[0]-evt.coordinate[0]);
@@ -666,6 +669,7 @@ ol_interaction_Transform.prototype.handleDragEvent_ = function(evt) {
     }
     default: break;
   }
+  this.isUpdating_ = false;
 };
 
 /**


### PR DESCRIPTION
This avoids O(n) drawSketch calls being run whenever a drag update event occurs. Previously the Transform would update all the selected features, call drawSketch, and then each features event listener would also call drawSketch.

It may also be worth considering throttling `drawSketch` as I've noticed it getting recomputed wayyyy to frequently