### PR TITLE
Add a performant way to override a Transform's selection collection

### DIFF
--- a/src/interaction/Transform.js
+++ b/src/interaction/Transform.js
@@ -401,6 +401,23 @@ ol_interaction_Transform.prototype.select = function(feature, add) {
   this.dispatchEvent({ type:'select', feature: feature, features: this.selection_ });
 };
 
+/** Update the selection collection.
+* @param {ol.Collection<ol.Feature>} features the features to transform
+*/
+ol_interaction_Transform.prototype.setSelection = function(features) {
+  this.selection_.clear();
+  features.forEach((feature) => {
+    this.selection_.push(feature);
+  });
+
+  this.ispt_ = (this.selection_.getLength()===1 ? (this.selection_.item(0).getGeometry().getType() == "Point") : false);
+  this.iscircle_ = (this.selection_.getLength()===1 ? (this.selection_.item(0).getGeometry().getType() == "Circle") : false);
+  this.drawSketch_();
+  this.watchFeatures_();
+  // select event
+  this.dispatchEvent({ type:'select', features: this.selection_ });
+};
+
 /** Watch selected features
  * @private
  */


### PR DESCRIPTION
Similar to #395, when using a transform with potentially many features in its selection set (100+) the current implementation is very slow due to having to recompute `drawSketch` for each selection add. This allows us to bulk change the selection and only then recompute the sketch. 