### PR TITLE
Fix the GeoRSS format to support Atom

### DIFF
--- a/src/format/GeoRSS.js
+++ b/src/format/GeoRSS.js
@@ -59,7 +59,6 @@ ol_format_GeoRSS.prototype.readFeature = function(source, options) {
       coord.push([parseFloat(temp[i+1]), parseFloat(temp[i])]) 
     }
     g = new ol_geom_Polygon([coord]);
-    console.log(temp,coord)
     f.unset('georss:polygon');
   } else if (f.get('georss:where')) {
     // GML
@@ -93,9 +92,9 @@ ol_format_GeoRSS.prototype.readFeatures = function(source, options) {
   if (typeof(source)==='string') {
     var parser = new DOMParser();
     var xmlDoc = parser.parseFromString(source,"text/xml");
-    items = xmlDoc.getElementsByTagName('item');
+    items = xmlDoc.getElementsByTagName(this.getDocumentItemsTagName(xmlDoc));
   } else if (source instanceof Document) {
-    items = source.getElementsByTagName('item');
+    items = source.getElementsByTagName(this.getDocumentItemsTagName(source));
   } else if (source instanceof Node) {
     items = source;
   } else {
@@ -110,5 +109,21 @@ ol_format_GeoRSS.prototype.readFeatures = function(source, options) {
 
   return features;
 };
+
+/**
+ * Get the tag name for the items in the XML Document depending if we are
+ * dealing with an atom base document or not.
+ * @param {Document} xmlDoc document to extract the tag name for the items
+ * @return {string} tag name
+ * @private
+ */
+ol_format_GeoRSS.prototype.getDocumentItemsTagName = function(xmlDoc) {
+  switch (xmlDoc.documentElement.tagName) {
+    case 'feed':
+      return 'entry';
+    default:
+      return 'item';
+  }
+}
 
 export default ol_format_GeoRSS


### PR DESCRIPTION
Look at https://en.wikipedia.org/wiki/GeoRSS for the difference between Atom and RSS 2.0.

A sample of a GeoRSS using Atom can also be found at http://www.georss.org/simple.html