### PR TITLE
Fixed Erroneous Behaviour with some projections

### DIFF
--- a/src/source/DayNight.js
+++ b/src/source/DayNight.js
@@ -152,8 +152,9 @@ ol_source_DayNight.prototype.getCoordinates = function (time, options) {
     default: {
       // Close polygon
       lat = (sunEqPos.delta < 0) ? 90 : -90;
-      lonlat.unshift([-180, lat]);
-      lonlat.push([180, lat]);
+      for(var tlon=180; tlon>=-180; tlon-=step){
+        lonlat.push([tlon,lat]);
+      }
       lonlat.push(lonlat[0])
       break;
     }


### PR DESCRIPTION
The 'lonlat' polygon created would have it filling inverted in some projections (for example the Azimuthal Equidistant projection where the sunlight projects an ellipsoid on the map). The fix would be to add some points to force the polygon to use the 'outside' area instead of the 'inside'.