### PR TITLE
Fix the georss format so the lat long are also parse as float

### DIFF
--- a/src/format/GeoRSS.js
+++ b/src/format/GeoRSS.js
@@ -44,7 +44,7 @@ ol_format_GeoRSS.prototype.readFeature = function(source, options) {
   // Get geometry
   if (f.get('geo:long')) {
     // LonLat
-    g = new ol_geom_Point([f.get('geo:long'), f.get('geo:lat')]);
+    g = new ol_geom_Point([parseFloat(f.get('geo:long')), parseFloat(f.get('geo:lat'))]);
     f.unset('geo:long');
     f.unset('geo:lat');
   } else if (f.get('georss:point')) {


### PR DESCRIPTION
While reprojecting coordinates to the map's projection, you can have issues if the lat long are considered as string.