### PR TITLE
Fixing TouchCursor unregistering 

### DIFF
--- a/src/interaction/TouchCursor.js
+++ b/src/interaction/TouchCursor.js
@@ -162,7 +162,7 @@ ol_interaction_TouchCursor.prototype.setMap = function(map) {
     this.getMap().removeInteraction(this.ctouch);
     if (this.getActive()) this.getMap().removeOverlay(this.overlay);
   }
-  for (let l in this._listeners) ol_Observable_unByKey(l);
+  for (let l in this._listeners) ol_Observable_unByKey(this._listeners[l]);
   this._listeners = {};
 
   ol_interaction_DragOverlay.prototype.setMap.call (this, map);

--- a/src/interaction/TouchCursor.js
+++ b/src/interaction/TouchCursor.js
@@ -162,7 +162,9 @@ ol_interaction_TouchCursor.prototype.setMap = function(map) {
     this.getMap().removeInteraction(this.ctouch);
     if (this.getActive()) this.getMap().removeOverlay(this.overlay);
   }
-  for (let l in this._listeners) ol_Observable_unByKey(this._listeners[l]);
+  for (let l in this._listeners) {
+    ol_Observable_unByKey(this._listeners[l]);
+  }
   this._listeners = {};
 
   ol_interaction_DragOverlay.prototype.setMap.call (this, map);


### PR DESCRIPTION
we found this bug in your code.

in your version you pass "addInteraction" to ol_Observable_unByKey, because of this the event is nor unregistered and if you try to add it a second time it will crash.
