### PR TITLE
Use ES5 syntax to keep consistency throughout the code and support older browsers

### DIFF
--- a/src/control/WMSCapabilities.js
+++ b/src/control/WMSCapabilities.js
@@ -563,13 +563,13 @@ ol_control_WMSCapabilities.prototype.showCapabilitis = function(caps) {
     html: 'layer...',
     className: 'ol-info',
     parent: this._elements.select,
-    click: () => {
+    click: function() {
       this._elements.buttons.innerHTML = '';
       this._elements.data.innerHTML = '';
       this._elements.legend.src = '';
       this._elements.legend.classList.remove('visible');
       this._elements.preview.src = '';
-    }
+    }.bind(this)
   });
   addLayers(caps.Capability.Layer);
 };


### PR DESCRIPTION
At this one place in the code, an arrow function is used. This causes an error in old browseres like IE11. With this minor change the consistency is kept throughout the code and will support older browseres.