### PR TITLE
Fix: Issue using layers and filter as functions

### DIFF
--- a/src/interaction/SelectCluster.js
+++ b/src/interaction/SelectCluster.js
@@ -46,7 +46,6 @@ import { extend as ol_extent_extend } from 'ol/extent'
  */
 var ol_interaction_SelectCluster = function(options) {
   options = options || {};
-  var fn; 
 
   this.pointRadius = options.pointRadius || 12;
   this.circleMaxObjects = options.circleMaxObjects || 10;
@@ -73,9 +72,9 @@ var ol_interaction_SelectCluster = function(options) {
   // Add the overlay to selection
   if (options.layers) {
     if (typeof(options.layers) == "function") {
-      fn = options.layers;
+      var fnLayers = options.layers;
       options.layers = function(layer) {
-        return (layer===overlay || fn(layer));
+        return (layer===overlay || fnLayers(layer));
       };
     } else if (options.layers.push) {
       options.layers.push(this.overlayLayer_);
@@ -84,11 +83,11 @@ var ol_interaction_SelectCluster = function(options) {
 
   // Don't select links
   if (options.filter) {
-    fn = options.filter;
+    var fnFilter = options.filter;
     options.filter = function(f,l){
       //if (l===overlay && f.get("selectclusterlink")) return false;
       if (!l && f.get("selectclusterlink")) return false;
-      else return fn(f,l);
+      else return fnFilter(f,l);
     };
   } else options.filter = function(f,l) {
     //if (l===overlay && f.get("selectclusterlink")) return false; 


### PR DESCRIPTION
Hello,

First of all, I'd like to thank you for such a great work done with these extensions; they've been extremely useful and a valuable tool for inspiration and learning.

I found an issue in a very specific use case where I needed to create a `SelectCluster` using both options `layers` and `filter` as separate functions. The filter function ended up overwriting the layers one, and looking at the source I found it was due to a variable called `fn` reused in the initialization blocks of said options. I made a simple fix to correct that by simply using separate variables.

I hope you agree with the changes or if you're aware of a better way to do it I'd be glad to know.