### PR TITLE
Fix #608: Swiping is broken for TileLayers

### DIFF
--- a/src/control/Swipe.js
+++ b/src/control/Swipe.js
@@ -277,7 +277,7 @@ ol_control_Swipe.prototype.precomposeRight = function(e) {
 ol_control_Swipe.prototype.postcompose = function(e) {
   // restore context when decluttering is done
   // https://github.com/openlayers/openlayers/issues/10096
-  if (e.target.getClassName()!=='ol-layer' && e.target.get('declutter')) {
+  if (e.target.className !== 'ol-layer' && e.target.get('declutter')) {
     setTimeout(function () {
       e.context.restore();
     }, 0);


### PR DESCRIPTION
As discussed in #608, this is a potential fix for swiping on OL5.