### PR TITLE
#620: Added callback function call to gulp lib task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -194,7 +194,7 @@ gulp.task("extrajs", function() {
 });
 
 // Build files to be used individually
-gulp.task("lib", function() {
+gulp.task("lib", function(cb) {
   var src = ['control','featureanimation','filter','format','geom','interaction','layer','overlay','render','source','style','util','utils','ext'];
   for (var i=0; i<src.length; i++) {
     gulp.src("./src/"+src[i]+"/*.js")
@@ -204,6 +204,7 @@ gulp.task("lib", function() {
       .pipe(autoprefixer('last 2 versions'))
       .pipe(gulp.dest("lib/"+src[i]));
   }
+  cb();
 });
 
 


### PR DESCRIPTION
Fixes #620.

- https://stackoverflow.com/questions/36897877/gulp-error-the-following-tasks-did-not-complete-did-you-forget-to-signal-async
   - Added callback function call to gulp lib task.