### PR TITLE
Fix misspelling of legend documentation

### DIFF
--- a/examples/legend/map.control.legend.html
+++ b/examples/legend/map.control.legend.html
@@ -52,7 +52,7 @@
     <h1>ol-ext: control Legend</h1>
   </a>
   <div class="info">
-    The <i>ol/control/Legend</i> computes a legend based on <i>ol/styl/Style</i> and draw it on the map.
+    The <i>ol/control/Legend</i> computes a legend based on <i>ol/style/Style</i> and draw it on the map.
     <ul>
       <li>
         You can add or remove rows in the legend. 

--- a/examples/legend/map.control.legends.html
+++ b/examples/legend/map.control.legends.html
@@ -48,7 +48,7 @@
     <h1>ol-ext: control Legends</h1>
   </a>
   <div class="info">
-    The <i>ol/control/Legend</i> computes a legend based on <i>ol/styl/Style</i> and draw it on the map.
+    The <i>ol/control/Legend</i> computes a legend based on <i>ol/style/Style</i> and draw it on the map.
     <br/>
     This example display a legend with 2 columns.
   </div>

--- a/examples/legend/map.control.legendstat.html
+++ b/examples/legend/map.control.legendstat.html
@@ -42,7 +42,7 @@
     <h1>ol-ext: control Legend</h1>
   </a>
   <div class="info">
-    The <i>ol/control/Legend</i> computes a legend based on <i>ol/styl/Style</i> and draw it on the map.
+    The <i>ol/control/Legend</i> computes a legend based on <i>ol/style/Style</i> and draw it on the map.
     <br/>
     This example displays a legend for a statistical map.
   </div>


### PR DESCRIPTION
Just found and fix some misspelling of the legend documentation.