### PR TITLE
Adding some new formatting option for Legend

### DIFF
--- a/src/legend/Legend.js
+++ b/src/legend/Legend.js
@@ -273,6 +273,12 @@ ol_legend_Legend.prototype.refresh = function() {
     if (item.feature || item.typeGeom) {
       canvas = this.getLegendImage(item, canvas, index);
       ctx.font = this._textItemStyle.getFont();
+      if(/\bitalic\b/.test(item.fontStyle)) {
+        ctx.font = 'italic ' + ctx.font;
+      }
+      if(/\bbold\b/.test(item.fontWeight)) {
+        ctx.font = 'bold ' + ctx.font;
+      }
       this._drawText(ctx, r.get('title'), width + margin, (i+1.5)*height);
     } else {
       ctx.font = this._textItemStyle.getFont();


### PR DESCRIPTION
1. added new style (textItemStyle), to styling inline items in a legend. The new style works like textStyle, but the default value is smaller. 
2. added new font style (fontStyle) and font weight (fontWeight) options, to styling the legends items. The accepted values for fontStyle are empty string or 'italic', for fontWeight are empty string or 'bold'.