### PR TITLE
[BUG] fix the bug that the mask filter does not work in some cases

### DIFF
--- a/src/filter/Mask.js
+++ b/src/filter/Mask.js
@@ -113,6 +113,10 @@ ol_filter_Mask.prototype.drawFeaturePath_ = function(e, out) {
     var fWidth = fExtent[2] - fExtent[1];
     var start = Math.floor((extent[0] + fWidth - worldExtent[0]) / worldWidth);
     var end = Math.floor((extent[2] - fWidth - worldExtent[2]) / worldWidth) +1;
+    
+    if(start > end) {
+        [start, end] = [end, start];
+    }
     for (var i=start; i<=end; i++) {
       drawll(i*worldWidth);
     }


### PR DESCRIPTION
This commit is to fix a bug that the mask/crop filter does not work in some cases - which could be reproduced by:

Replace the feature of mask in example `examples/filter/map.filter.crop.html` with the following one:
```
{
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "MultiPolygon",
        "coordinates": [[[[11346341, 4246048],[12600493, 2595848],[15765340, 4618799], [11346341, 4246048]]]]
      }
}
```
Start the program and view the exmaple page, everything works fine util the zoom level of map is greater than 8.