### PR TITLE
fix: Update opacity label after click on LayerSwitcher

### DIFF
--- a/src/control/LayerSwitcher.js
+++ b/src/control/LayerSwitcher.js
@@ -883,6 +883,7 @@ ol_control_LayerSwitcher.prototype.drawList = function(ul, collection) {
         e.preventDefault();
         var op = Math.max ( 0, Math.min( 1, e.offsetX / ol_ext_element.getStyle(this, 'width')));
         self._getLayerForLI(this.parentNode.parentNode).setOpacity(op);
+        this.parentNode.querySelectorAll('.layerswitcher-opacity-label')[0].innerHTML = Math.round(op * 100);
       },
       parent: d
     });


### PR DESCRIPTION
In the actual example of [LayerSwitcher](https://viglino.github.io/ol-ext/examples/control/map.switcher.html), the opacity label is not updated after click on opacity line. (Dragging mode works fine.)

The pull request contains a fix to update the opacity label after click on opacity label.