### PR TITLE
Check existence of "ol.ext" before initializing "ol.ext.input" and "ol.ext.imageLoader"

### DIFF
--- a/src/util/imagesLoader.js
+++ b/src/util/imagesLoader.js
@@ -2,7 +2,9 @@ import { asArray as ol_color_asArray } from 'ol/color'
 
 /** @namespace ol.ext.imageLoader
  */
-if (window.ol) window.ol.ext.imageLoader = {};
+if (window.ol && ol.ext && !ol.ext.imageLoader) {
+  ol.ext.imageLoader = {};
+}
 
 /** Helper for loading BIL-32 (Band Interleaved by Line) image
  * @param {string} src

--- a/src/util/input/Base.js
+++ b/src/util/input/Base.js
@@ -6,7 +6,7 @@ import ol_Object from 'ol/Object'
 /** @namespace  ol.ext.input
  */
 /*global ol*/
-if (window.ol) {
+if (window.ol && ol.ext && !ol.ext.input) {
   ol.ext.input = {};
 }
 


### PR DESCRIPTION
@Viglino, @Siedlerchr 
Related with https://github.com/Siedlerchr/types-ol-ext/pull/96, checking existence of `ol.ext` before initializing `ol.ext.input` seems to be necessary for types-ol-ext example, so I added further checks by referring other similar part (https://github.com/Viglino/ol-ext/search?q=window.ol).

Also, I noticed that `ol.ext.imageLoader` is similar with `ol.ext.input`, so I fixed it also.