### PR TITLE
docs: update options in jsdoc for swipe & swipe-map control

### DIFF
--- a/doc/doc-pages/ol.control.Swipe.html
+++ b/doc/doc-pages/ol.control.Swipe.html
@@ -185,6 +185,9 @@
             
                 
 <span class="param-type"><a href="ol.layer.html">ol.layer</a></span>
+|
+
+<span class="param-type">Array.&lt;<a href="ol.layer.html">ol.layer</a>></span>
 
 
 
@@ -203,20 +206,23 @@
 
             
 
-            <td class="description last"><p>layer to swipe</p></td>
+            <td class="description last"><p>layers to swipe</p></td>
         </tr>
 
     
 
         <tr>
             
-                <td class="name"><code>options.rightLayer</code></td>
+                <td class="name"><code>options.rightLayers</code></td>
             
 
             <td class="type">
             
                 
 <span class="param-type"><a href="ol.layer.html">ol.layer</a></span>
+|
+
+<span class="param-type">Array.&lt;<a href="ol.layer.html">ol.layer</a>></span>
 
 
 
@@ -235,7 +241,7 @@
 
             
 
-            <td class="description last"><p>layer to swipe on right side</p></td>
+            <td class="description last"><p>layers to swipe on right side</p></td>
         </tr>
 
     
@@ -299,7 +305,7 @@
 
             
 
-            <td class="description last"><p>position propertie of the swipe [0,1], default 0.5</p></td>
+            <td class="description last"><p>position property of the swipe [0,1], default 0.5</p></td>
         </tr>
 
     
@@ -331,7 +337,7 @@
 
             
 
-            <td class="description last"><p>orientation propertie (vertical|horizontal), default vertical</p></td>
+            <td class="description last"><p>orientation property (vertical|horizontal), default vertical</p></td>
         </tr>
 
     

--- a/doc/doc-pages/ol.control.SwipeMap.html
+++ b/doc/doc-pages/ol.control.SwipeMap.html
@@ -178,70 +178,6 @@
 
         <tr>
             
-                <td class="name"><code>options.layers</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type"><a href="ol.layer.html">ol.layer</a></span>
-
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>layer to swipe</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
-                <td class="name"><code>options.rightLayer</code></td>
-            
-
-            <td class="type">
-            
-                
-<span class="param-type"><a href="ol.layer.html">ol.layer</a></span>
-
-
-
-            
-            </td>
-
-            
-                <td class="attributes">
-                
-
-                
-
-                
-                </td>
-            
-
-            
-
-            <td class="description last"><p>layer to swipe on right side</p></td>
-        </tr>
-
-    
-
-        <tr>
-            
                 <td class="name"><code>options.className</code></td>
             
 
@@ -299,7 +235,7 @@
 
             
 
-            <td class="description last"><p>position propertie of the swipe [0,1], default 0.5</p></td>
+            <td class="description last"><p>position property of the swipe [0,1], default 0.5</p></td>
         </tr>
 
     
@@ -331,7 +267,39 @@
 
             
 
-            <td class="description last"><p>orientation propertie (vertical|horizontal), default vertical</p></td>
+            <td class="description last"><p>orientation property (vertical|horizontal), default vertical</p></td>
+        </tr>
+
+    
+
+        <tr>
+            
+                <td class="name"><code>options.right</code></td>
+            
+
+            <td class="type">
+            
+                
+<span class="param-type">boolean</span>
+
+
+
+            
+            </td>
+
+            
+                <td class="attributes">
+                
+
+                
+
+                
+                </td>
+            
+
+            
+
+            <td class="description last"><p>true to position map on right side (resp. bottom for horizontal orientation), default false</p></td>
         </tr>
 
     

--- a/src/control/Swipe.js
+++ b/src/control/Swipe.js
@@ -12,11 +12,11 @@ import ol_control_Control from 'ol/control/Control.js'
  * @constructor
  * @extends {ol_control_Control}
  * @param {Object=} Control options.
- *  @param {ol.layer} options.layers layer to swipe
- *  @param {ol.layer} options.rightLayer layer to swipe on right side
+ *  @param {ol.layer|Array<ol.layer>} options.layers layers to swipe
+ *  @param {ol.layer|Array<ol.layer>} options.rightLayers layers to swipe on right side
  *  @param {string} options.className control class name
- *  @param {number} options.position position propertie of the swipe [0,1], default 0.5
- *  @param {string} options.orientation orientation propertie (vertical|horizontal), default vertical
+ *  @param {number} options.position position property of the swipe [0,1], default 0.5
+ *  @param {string} options.orientation orientation property (vertical|horizontal), default vertical
  */
 var ol_control_Swipe = class olcontrolSwipe extends ol_control_Control {
   constructor(options) {

--- a/src/control/SwipeMap.js
+++ b/src/control/SwipeMap.js
@@ -13,11 +13,10 @@ import {unByKey as ol_Observable_unByKey} from 'ol/Observable.js'
  * @constructor
  * @extends {ol_control_Control}
  * @param {Object=} Control options.
- *  @param {ol.layer} options.layers layer to swipe
- *  @param {ol.layer} options.rightLayer layer to swipe on right side
  *  @param {string} options.className control class name
- *  @param {number} options.position position propertie of the swipe [0,1], default 0.5
- *  @param {string} options.orientation orientation propertie (vertical|horizontal), default vertical
+ *  @param {number} options.position position property of the swipe [0,1], default 0.5
+ *  @param {string} options.orientation orientation property (vertical|horizontal), default vertical
+ *  @param {boolean} options.right true to position map on right side (resp. bottom for horizontal orientation), default false
  */
 var ol_control_SwipeMap = class olcontrolSwipeMap extends ol_control_Control {
   constructor(options) {


### PR DESCRIPTION
The JSDocs comments are missing some options for the two swipe controls:

1. Swipe control: can accept an array of layers for `options.layers` and `options.rightLayers` (https://github.com/Viglino/ol-ext/blob/master/src/control/Swipe.js#L43)
2. Swipe map control: the JSDoc was missing the `right` option. Additionally the options for layers are not used for this control and can be removed.