### PR TITLE
support length 2 font (Material Design Icons)

### DIFF
--- a/src/style/FontSymbol.js
+++ b/src/style/FontSymbol.js
@@ -95,7 +95,7 @@ var ol_style_FontSymbol = class olstyleFontSymbol extends ol_style_RegularShape 
     ol_style_FontSymbol.defs.fonts[fontname] = thefont;
     for (var i in glyphs) {
       var g = glyphs[i];
-      if (typeof (g) === 'string' && g.length == 1) {
+      if (typeof (g) === 'string' && (g.length == 1 || g.length == 2)) {
         g = { char: g };
       }
       ol_style_FontSymbol.defs.glyphs[i] = {


### PR DESCRIPTION
Supports char as length 2.
Material Design Icons use this pattern.

see: https://github.com/gtt-project/redmine_gtt/blob/d9b698925c68f13d3b515b4ea2d34c6ec0a7d7a0/src/stylesheets/MaterialDesignDef.js
see also: https://github.com/Templarian/MaterialDesign-Webfont/blob/master/css/materialdesignicons.css