### PR TITLE
Added `buffer` option to Transform interaction

### DIFF
--- a/src/interaction/Transform.js
+++ b/src/interaction/Transform.js
@@ -36,6 +36,7 @@ import ol_geom_Polygon from 'ol/geom/Polygon.js'
  *	@param {ol.events.ConditionType | undefined} options.modifyCenter A function that takes an ol.MapBrowserEvent and returns a boolean to apply scale & strech from the center, default ol.events.condition.metaKey or ol.events.condition.ctrlKey.
  *	@param {boolean} options.enableRotatedTransform Enable transform when map is rotated
  *	@param {boolean} [options.keepRectangle=false] keep rectangle when possible
+ *  @param {number} [options.buffer] Increase the extent used as bounding box, default 0
  *	@param {*} options.style list of ol.style for handles
  *  @param {number|Array<number>|function} [options.pointRadius=0] radius for points or a function that takes a feature and returns the radius (or [radiusX, radiusY]). If not null show handles to transform the points
  */
@@ -105,7 +106,8 @@ var ol_interaction_Transform = class olinteractionTransform extends ol_interacti
     this.set('enableRotatedTransform', (options.enableRotatedTransform || false))
     /* Keep rectangle angles 90 degrees */
     this.set('keepRectangle', (options.keepRectangle || false))
-
+    /* Add buffer to the feature's extent */
+    this.set('buffer', (options.buffer || 0))
 
     // Force redraw when changed
     this.on('propertychange', function () {
@@ -355,7 +357,7 @@ var ol_interaction_Transform = class olinteractionTransform extends ol_interacti
       coords.unshift(coords[3])
     }
     // Clone and extend
-    ext = ol_extent_buffer(ext, 0)
+    ext = ol_extent_buffer(ext, this.get('buffer'))
     this.selection_.forEach(function (f) {
       var extendExt = this.getGeometryRotateToZero_(f).getExtent()
       ol_extent_extend(ext, extendExt)


### PR DESCRIPTION
This PR is to avoid cases where there is a juxtaposition of the bounding box and the feature's vertexs, wich happens on LinesStrings that are perfectly diagonal (see images). 

The problem occurs, for example, if you want to click and drag (with a Modify Interaction + TransformBox), the points that are behind the bbox, at the corners... By adding some _optional_ buffer to the calculated extent this problem disappear.

Default is 0, so there is no change to the current behaiviour.

Without buffer:
![buffer0](https://user-images.githubusercontent.com/34213485/233821775-f0ba93df-58d3-4904-aea7-f37fde2409fc.PNG)

With some buffer:
![buffer100](https://user-images.githubusercontent.com/34213485/233821778-0e2effeb-d02b-4346-abf0-aed157544353.PNG)
