### PR TITLE
options.offset type is incomplete in both style/FillPattern.js and style/StrokePattern.js

### DIFF
--- a/doc/doc-pages/ol.style.FillPattern.html
+++ b/doc/doc-pages/ol.style.FillPattern.html
@@ -318,6 +318,9 @@
             
                 
 <span class="param-type">number</span>
+|
+
+<span class="param-type">[number, number]</span>
 
 
 

--- a/doc/doc-pages/ol.style.StrokePattern.html
+++ b/doc/doc-pages/ol.style.StrokePattern.html
@@ -318,6 +318,9 @@
             
                 
 <span class="param-type">number</span>
+|
+
+<span class="param-type">[number, number]</span>
 
 
 

--- a/src/style/FillPattern.js
+++ b/src/style/FillPattern.js
@@ -18,7 +18,7 @@ import {asString as ol_color_asString} from 'ol/color.js'
  *  @param {string} options.pattern pattern name (override by image option)
  *  @param {ol_color} options.color pattern color
  *  @param {ol_style_Fill} options.fill fill color (background)
- *  @param {number} options.offset pattern offset for hash/dot/circle/cross pattern
+ *  @param {number|[number, number]} options.offset pattern offset for hash/dot/circle/cross pattern
  *  @param {number} options.size line size for hash/dot/circle/cross pattern
  *  @param {number} options.spacing spacing for hash/dot/circle/cross pattern
  *  @param {number|bool} options.angle angle for hash pattern / true for 45deg dot/circle/cross

--- a/src/style/StrokePattern.js
+++ b/src/style/StrokePattern.js
@@ -19,7 +19,7 @@ import ol_style_FillPattern from './FillPattern.js'
  *	@param {string} options.pattern pattern name (override by image option)
  *	@param {ol.colorLike} options.color pattern color
  *	@param {ol.style.Fill} options.fill fill color (background)
- *	@param {number} options.offset pattern offset for hash/dot/circle/cross pattern
+ *	@param {number|[number, number]} options.offset pattern offset for hash/dot/circle/cross pattern
  *	@param {number} options.size line size for hash/dot/circle/cross pattern
  *	@param {number} options.spacing spacing for hash/dot/circle/cross pattern
  *	@param {number|bool} options.angle angle for hash pattern / true for 45deg dot/circle/cross


### PR DESCRIPTION
In both `style/FillPattern.js` and `style/StrokePattern.js`, parameter `options.offset` is typed as:

`@param {number} options.offset pattern offset for hash/dot/circle/cross pattern`

However, the code in both classes also accepts an 2-dimensional array of numbers [x,y], and this is sometimes a must-have option (for ex. if you have hatches oriented at an angle of 135°, you can't simply pass a single number in the `options.offset`: it won't work! In such cases, you definitely need to pass an array of 2 different numbers).

Thus, the correct code should be:

`@param {number|[number, number]} options.offset pattern offset for hash/dot/circle/cross pattern`

Note that it also impacts incorrect (incomplete) types to be generated by [`Siedlrchr/types-ol-ext`](https://github.com/Siedlerchr/types-ol-ext/pull/128).

Thanks for all your amazing work on this project,
Best regards