### PR TITLE
#1048:  Layerswitcher re-ordering issue in web component

### DIFF
--- a/src/control/LayerSwitcher.js
+++ b/src/control/LayerSwitcher.js
@@ -594,8 +594,18 @@ var ol_control_LayerSwitcher = class olcontrolLayerSwitcher extends ol_control_C
         var li
         if (!e.touches) {
           li = e.target
+          
+          // Get the HTML node within web component on click drag
+          if(e.target.shadowRoot){
+            li = e.composedPath()[0]
+          }
         } else {
-          li = document.elementFromPoint(e.touches[0].clientX, e.touches[0].clientY)
+          li = document.elementFromPoint(e.touches[0].clientX, e.touches[0].clientY);
+          
+          //Get actual HTML node within web component on touch drag
+          while(li.shadowRoot){
+            li = li.shadowRoot.elementFromPoint(e.touches[0].clientX, e.touches[0].clientY)
+          }
         }
         if (li.classList.contains("ol-switcherbottomdiv")) {
           self.overflow(-1)


### PR DESCRIPTION
**Problem:**
LayerSwitcher layer ordering not working inside web components.

Example:  https://codesandbox.io/p/sandbox/pedantic-leaf-hf2z7d?file=%2Fsrc%2Findex.js

https://github.com/Viglino/ol-ext/issues/1048