### PR TITLE
Fix calculation of extent around a point when a buffer is used

### DIFF
--- a/src/interaction/Transform.js
+++ b/src/interaction/Transform.js
@@ -382,7 +382,7 @@ var ol_interaction_Transform = class olinteractionTransform extends ol_interacti
     } else {
       if (this.ispt_) {
         // Calculate extent arround the point
-        var p = this.getMap().getPixelFromCoordinate([ext[0], ext[1]])
+        var p = this.getMap().getPixelFromCoordinate(ol_extent_getCenter(ext))
         if (p) {
           var dx = ptRadius ? ptRadius[0] || 10 : 10
           var dy = ptRadius ? ptRadius[1] || 10 : 10


### PR DESCRIPTION
When a buffer is applied and a pointRadius is set, the handles are drawn at the bottom left of the extent instead of the center.

This PR fixes this.


@Viglino thx for this amazing lib.