### PR TITLE
Fix invalid CSS prop in color picker

### DIFF
--- a/src/util/input/Color.css
+++ b/src/util/input/Color.css
@@ -139,7 +139,7 @@
   height: 150px;
   border: 5px solid #fff;
   border-width: 5px 0;
-  box-sizing: border;
+  box-sizing: border-box;
   top: 0;
   right: 5px;
   background-image: linear-gradient(0, #f00, #f0f, #00f, #0ff, #0f0, #ff0, #f00)


### PR DESCRIPTION
```
Error: CSS: box-sizing: border is not a box-sizing value.
```

I had this come up on a w3 validator report for a site I work on, and tracked it back to this repo. Hope this is ok!
