### PR TITLE
Fix gridbin size issue

### DIFF
--- a/src/source/GridBin.js
+++ b/src/source/GridBin.js
@@ -22,7 +22,7 @@ var ol_source_GridBin = class olsourceGridBin extends ol_source_BinBase {
     super(options);
 
     this.set('gridProjection', options.gridProjection || 'EPSG:4326');
-    this.setSize('size', options.size || 1);
+    this.setSize(options.size || 1);
     this.reset();
   }
   /** Set grid projection


### PR DESCRIPTION
Right now if you want to create a GridBin, the center is always NaN or Infinity. This PR fixes this issue by passing the correct params to the `setSize` function.