### PR TITLE
[DOC] homepage fix webpack icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
     <br/>
       More example for use in:
       <a href="https://github.com/darkscript/ol-ol-ext-webpack-example">
-        <img src="https://camo.githubusercontent.com/d18f4a7a64244f703efcb322bf298dcb4ca38856/68747470733a2f2f7765627061636b2e6a732e6f72672f6173736574732f69636f6e2d7371756172652d6269672e737667" style="height:2em; vertical-align:middle;" />webpack
+        <img src="https://raw.githubusercontent.com/webpack/media/master/logo/icon-square-small.svg" style="height:2em; vertical-align:middle;" />webpack
       </a>
       <a href="https://github.com/Viglino/ol-ext-parcel-bundler">
         <img src="https://parceljs.org/parcel.fb905a63.png" style="height:2em; vertical-align:middle;" />parcel


### PR DESCRIPTION
Hi @Viglino,

fix image url error in the homepage
![webpack](https://github.com/Viglino/ol-ext/assets/1088155/aed3148a-942b-4565-a091-5fd7dc8c36d8)

good afternoon