### PR TITLE
Adds missing file extension

### DIFF
--- a/src/interaction/Hover.js
+++ b/src/interaction/Hover.js
@@ -1,5 +1,5 @@
 import ol_interaction_Interaction from 'ol/interaction/Interaction.js'
-import ol_ext_element from '../util/element';
+import ol_ext_element from '../util/element.js';
 
 /** Interaction hover do to something when hovering a feature
  * @constructor


### PR DESCRIPTION
Similar to https://github.com/Viglino/ol-ext/issues/1088 a file extension is also missing in `Hover.js`