### PR TITLE
FixedPopup: Allows fixing the popup on coordinates

### DIFF
--- a/examples/popup/map.fixedpopup.html
+++ b/examples/popup/map.fixedpopup.html
@@ -135,18 +135,18 @@
       <option value="tooltips">tooltips</option>
     </select>
     <br />
-    <input id="ck" type="checkbox" onchange="if (this.checked) popup.addPopupClass('shadow'); else popup.removePopupClass('shadow');" />
+    <input id="ck" type="checkbox" onchange="this.checked ? popup.addPopupClass('shadow') & popup2.addPopupClass('shadow') : popup.removePopupClass('shadow') & popup2.removePopupClass('shadow')" />
     <label for="ck">shadow</label>
     <br />
-    <input id="cb" type="checkbox" checked onchange="popup.setClosebox(this.checked);" />
+    <input id="cb" type="checkbox" checked onchange="popup.setClosebox(this.checked); popup2.setClosebox(this.checked);" />
     <label for="cb">hasclosebox</label>
     <br />
     <label>
-      <input name="fix" type="radio" checked onchange="popup.setHook('viewport');"  />
+      <input name="fix" type="radio" checked onchange="popup.setHook('viewport'); popup2.setHook('viewport')"  />
       hook on viewport
     </label>
     <label>
-      <input name="fix" type="radio" onchange="popup.setHook('map');" />
+      <input name="fix" type="radio" onchange="popup.setHook('map'); popup2.setHook('map')" />
       hook on map
     </label>
   </div>


### PR DESCRIPTION
### Purpose
Allow FixedPopup class to be fixed on map coordinates. Similar to a popup, while retaining the functionality to be moved around on the map. This is an enhancement to the fixed popup. 

### How
A new parameter "fixedPosition" is passed when creating the popup, if set to true it saves the coordinates of the popup and updates pixel position of the popup accordingly when the map is moved so the popup stays on the saved coordinates. 

Also addresses the minor point of options on the example html page not applying to the second popup. (see lines 138 & 141 @ `fixedpopup.html`)
