### PR TITLE
Fix DrawRegular interaction on touch device

### DIFF
--- a/src/interaction/DrawRegular.js
+++ b/src/interaction/DrawRegular.js
@@ -259,7 +259,8 @@ var ol_interaction_DrawRegular = class olinteractionDrawRegular extends ol_inter
   handleEvent_(evt) {
     var dx, dy
     // Event date time
-    this._eventTime = new Date()
+    this._eventTime = new Date();
+
     switch (evt.type) {
       case "pointerdown": {
         if (this.conditionFn_ && !this.conditionFn_(evt))
@@ -274,6 +275,7 @@ var ol_interaction_DrawRegular = class olinteractionDrawRegular extends ol_inter
           if (this._longTouch)
             this.handleMoveEvent_(evt)
         }.bind(this), dt)
+        this.lastEvent = evt.type;
         break
       }
       case "pointerup": {
@@ -281,9 +283,10 @@ var ol_interaction_DrawRegular = class olinteractionDrawRegular extends ol_inter
         if (this.started_ && this.coord_) {
           dx = this.downPx_[0] - evt.pixel[0]
           dy = this.downPx_[1] - evt.pixel[1]
+
           if (dx * dx + dy * dy <= this.squaredClickTolerance_) {
             // The pointer has moved
-            if (this.lastEvent == "pointermove" || this.lastEvent == "keydown") {
+            if (this.lastEvent == "pointerdown" || this.lastEvent == "pointermove" || this.lastEvent == "keydown") {
               this.end_(evt)
             }
 
@@ -327,12 +330,13 @@ var ol_interaction_DrawRegular = class olinteractionDrawRegular extends ol_inter
         break
       }
       default: {
-        this.lastEvent = evt.type
-        // Prevent zoom in on dblclick
-        if (this.started_ && evt.type === 'dblclick') {
+        // Prevent zoom or other event on click/singleclick/dblclick
+        if (this.started_ && (evt.type === 'click' || evt.type === 'singleclick' || evt.type === 'dblclick')) {
           //evt.stopPropagation();
           return false
         }
+        this.lastEvent = evt.type
+
         break
       }
     }


### PR DESCRIPTION
On touch device the pointermove event is never triggered.  
So on the second click to finish the Regular Shape, the `lastEvent` variable is set to `singleclick`, which make impossible to end the drawing
 
To fix it I choose to ignore `click` and `singleclick`  which probably make sense because, if you don't want to trigger the `dblclick` on the map, probably  you also don't want to propagate `singleclick`and `click`to otheres interactions.

And the `lastEvent` variable is also set on pointerdown so the pointerup knows that we are in a pointer down/up sequence.