### PR TITLE
[BUG] FontSymbol.addDefs need to handle utf32 symbols

### DIFF
--- a/src/style/FontSymbol.js
+++ b/src/style/FontSymbol.js
@@ -108,7 +108,7 @@ var ol_style_FontSymbol = class olstyleFontSymbol extends ol_style_RegularShape 
       }
       ol_style_FontSymbol.defs.glyphs[i] = {
         font: thefont.font,
-        char: g.char || '' + String.fromCharCode(g.code) || '',
+        char: g.char || '' + String.fromCodePoint(g.code) || '',
         theme: g.theme || thefont.name,
         name: g.name || i,
         search: g.search || ''


### PR DESCRIPTION
Previous code doesn't handle glyph code with encoding > utf16