### PR TITLE
Some minor improvements on Profile style

### DIFF
--- a/src/style/Profile.js
+++ b/src/style/Profile.js
@@ -126,8 +126,11 @@ var ol_style_Profile = class olstyleProfile extends ol_style_Style {
     for (i = 0; p = geom[i]; i++) {
       var x = dx + p[0] * a * cos + p[1] * a * sin
       var y = dy + p[0] * a * sin - p[1] * a * cos
-      dz = Math.min(dz, p[2])
-      geom[i] = [x, y, p[2]]
+      var z = p[2]
+      if (typeof z === 'number') {
+        dz = Math.min(dz, z)
+      }
+      geom[i] = [x, y, z]
     }
 
     ctx.save()
@@ -143,8 +146,10 @@ var ol_style_Profile = class olstyleProfile extends ol_style_Style {
       ctx.beginPath()
       ctx.moveTo(p0[0], p0[1])
       ctx.lineTo(p[0], p[1])
-      ctx.lineTo(p[0], p[1] - (p[2] - dz) * ez)
-      ctx.lineTo(p0[0], p0[1] - (p0[2] - dz) * ez)
+      if (typeof p[2] === 'number') {
+        ctx.lineTo(p[0], p[1] - (p[2] - dz) * ez)
+        ctx.lineTo(p0[0], p0[1] - (p0[2] - dz) * ez)
+      }
       ctx.lineTo(p0[0], p0[1])
       ctx.fill()
       p0 = p
@@ -161,9 +166,11 @@ var ol_style_Profile = class olstyleProfile extends ol_style_Style {
       ctx.moveTo(p0[0] + vertexSize, y0);
 
       for (i = 1; p = geom[i]; i++) {
+        if (typeof p[2] === 'number' ) {
           var yElev = p[1] - (p[2] - dz) * ez;
           ctx.arc(p[0], yElev, vertexSize, 0, 2 * Math.PI);
           ctx.moveTo(p[0] + vertexSize, yElev);
+        }
       };
       ctx.fill();
     }


### PR DESCRIPTION
- Added support for `undefined` z values without breaking the entire graph. In coordinates where there is no elevation information (for example, the black path in the attached image), it will not be drawn, but the rest will.
- The first and last geometry vertices are now also rendered

<img width="624" height="480" alt="Captura de pantalla 2025-08-18 100704" src="https://github.com/user-attachments/assets/083d07a9-7b23-4c63-852b-9bba3a0e906c" />
